### PR TITLE
Fixed QueryParams PR. Added Test

### DIFF
--- a/src/main/groovy/io/ark/core/Peer.groovy
+++ b/src/main/groovy/io/ark/core/Peer.groovy
@@ -25,7 +25,8 @@ class Peer extends Object {
     }
 
     // return Future that will deliver the JSON as a Map
-    public Future request(String method, String path, body = [:]){
+    // the "query" argument allows to pass URL parameters as param1: 'value1', param2: 'value2'... string
+    public Future request(String method, String path, query = [:], body = [:]){
         if(!http)
             http = new AsyncHTTPBuilder(uri: "${protocol}${ip}:${port}")
 
@@ -45,6 +46,7 @@ class Peer extends Object {
 
         http.request(_method, JSON) {
             uri.path = path
+            uri.query = query
             headers << networkHeaders
             body = body
 

--- a/src/test/groovy/NetworkTest.groovy
+++ b/src/test/groovy/NetworkTest.groovy
@@ -77,6 +77,16 @@ class NetworkTest extends Specification {
         result == mainnet.broadcastMax
     }
 
+    def "Should filter get request with query params"(){
+        setup:
+        def peer = mainnet.randomPeer
+        when:
+        def result = peer.request("GET", "/api/blocks/", [ offset:'100', limit: '50' ]).get()
+        then:
+        result.get("success") == true
+        (result.get("blocks") as List).size() == 50
+    }
+
     def "Should Get transactions associated with an Account"(){
         setup:
         def peer = mainnet.randomPeer


### PR DESCRIPTION
@fix This commit cleans up the code in #17 and adds a test to verify it's functionality. 
Changed `rawQuery` to `query` which lets us use a map of query params instead of a string
Thanks @Maxinger for coming up with the idea
